### PR TITLE
Prevent overheating in biodigester control

### DIFF
--- a/biodigester_control_loop.py
+++ b/biodigester_control_loop.py
@@ -183,12 +183,19 @@ class SimpleBiodigester:
 
         max_power = self.current_profile['max_power']
 
+        # Do not heat if we're already at or above the target temperature
+        # Negative temperature error means the current temperature is higher
+        # than the target and heating would push the system even further
+        # out of range.
+        if temp_error <= 0:
+            return 0
+
         # Very conservative power calculation for biological systems
-        if abs(temp_error) <= 0.5:
+        if temp_error <= 0.5:
             return 5  # Minimal maintenance heating
-        elif abs(temp_error) <= 2.0:
+        elif temp_error <= 2.0:
             return min(15, max_power)  # Gentle heating
-        elif abs(temp_error) <= 5.0:
+        elif temp_error <= 5.0:
             return min(25, max_power)  # Moderate heating
         else:
             return min(35, max_power)  # Maximum safe heating

--- a/tests/test_biodigester_power.py
+++ b/tests/test_biodigester_power.py
@@ -1,0 +1,43 @@
+import sys
+import types
+from pathlib import Path
+
+# Stub hardware-specific modules before importing the module under test
+for name in ["board", "busio", "digitalio", "adafruit_scd30"]:
+    sys.modules[name] = types.ModuleType(name)
+
+onewire = types.ModuleType("onewire")
+onewire.OneWire = object
+sys.modules["onewire"] = onewire
+
+ds18x20 = types.ModuleType("ds18x20")
+ds18x20.DS18X20 = object
+sys.modules["ds18x20"] = ds18x20
+
+# Ensure the project root is on the import path
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from biodigester_control_loop import SimpleBiodigester
+
+
+def make_controller():
+    ctrl = SimpleBiodigester.__new__(SimpleBiodigester)
+    ctrl.active = True
+    ctrl.emergency_stop = False
+    ctrl.current_profile = {"max_power": 40}
+    return ctrl
+
+
+def test_no_heating_when_above_target():
+    ctrl = make_controller()
+    assert ctrl.calculate_power(-0.1) == 0
+    assert ctrl.calculate_power(0.0) == 0
+
+
+def test_power_increases_with_positive_error():
+    ctrl = make_controller()
+    assert ctrl.calculate_power(0.2) == 5
+    assert ctrl.calculate_power(1.0) == 15
+    assert ctrl.calculate_power(3.0) == 25
+    assert ctrl.calculate_power(10.0) == 35


### PR DESCRIPTION
## Summary
- Fix power calculation to avoid heating when current temperature exceeds target
- Add unit tests covering power calculation logic

## Testing
- `pytest tests/test_biodigester_power.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6896721ac27c83268abdbfc5ec640bcb